### PR TITLE
build(misc): integrate with sonarcloud to support java and nodejs code coverage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,8 +68,8 @@ jobs:
       - name: Build and analyze SDK
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-        run: |
-            mvn -B verify
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=mycloudnexus_kraken_java
 
   nodejs-unit-test:
     name: nodejs-unit-test
@@ -113,3 +113,10 @@ jobs:
       # some repos don't have unit test now, need to add in future.
       - run: CHROME_BIN=$(which chrome) npm run test:coverage -- -u
         working-directory: ./kraken-app/kraken-app-portal
+
+      - name: SonarCloud Scan
+        if: success() || failure()
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,26 @@
         <lombok.version>1.18.34</lombok.version>
         <org.lombok-mapstruct-binding.version>0.2.0</org.lombok-mapstruct-binding.version>
         <org.mapstruct.version>1.6.0</org.mapstruct.version>
+
+
+        <sonar.organization>mycloudnexus</sonar.organization>
+        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <sonar.projectName>kraken_java</sonar.projectName>
+        <sonar.coverage.jacoco.xmlReportPaths>
+            ${project.basedir}/kraken-java-sdk/kraken-java-sdk-core/target/site/jacoco-aggregate/jacoco.xml,
+            ${project.basedir}/kraken-java-sdk/kraken-java-sdk-gateway/target/site/jacoco-aggregate/jacoco.xml,
+            ${project.basedir}/kraken-java-sdk/kraken-java-sdk-data/target/site/jacoco-aggregate/jacoco.xml,
+            ${project.basedir}/kraken-java-sdk/kraken-java-sdk-sync/target/site/jacoco-aggregate/jacoco.xml,
+            ${project.basedir}/kraken-java-sdk/kraken-java-sdk-controller/target/site/jacoco-aggregate/jacoco.xml,
+            ${project.basedir}/kraken-java-sdk/kraken-java-sdk-mef/target/site/jacoco-aggregate/jacoco.xml,
+            ${project.basedir}/kraken-app/kraken-app-hub/target/site/jacoco-aggregate/jacoco.xml,
+            ${project.basedir}/kraken-app/kraken-app-agent/target/site/jacoco-aggregate/jacoco.xml,
+            ${project.basedir}/kraken-app/kraken-app-mgmt/target/site/jacoco-aggregate/jacoco.xml
+        </sonar.coverage.jacoco.xmlReportPaths>
+        <sonar.exclusions>
+            ${project.basedir}/kraken-java-sdk/kraken-java-sdk-test/**
+            ${project.basedir}/kraken-app/kraken-app-portal/**
+        </sonar.exclusions>
     </properties>
 
     <build>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,18 @@
+sonar.host.url=https://sonarcloud.io
+sonar.projectKey=mycloudnexus_kraken_nodejs
+sonar.organization=mycloudnexus
+
+# This is the name and version displayed in the SonarCloud UI.
+sonar.projectName=kraken_nodejs
+#sonar.projectVersion=1.0
+
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+sonar.sources=./kraken-app/kraken-app-portal
+
+# Encoding of the source code. Default is default system encoding
+sonar.sourceEncoding=UTF-8
+
+sonar.coverage.exclusions= ./kraken-app/kraken-app-portal/src/utils/**, ./kraken-app/kraken-app-portal/src/services/**, ./kraken-app/kraken-app-portal/src/hooks/**, ./kraken-app/kraken-app-portal/src/constants/**, ./kraken-app/kraken-app-portal/src/store/**, ./kraken-app/kraken-app-portal/src/store/**,  **/*.constant.tsx, **/*.constant.ts, ./kraken-app/kraken-app-portal/src/libs/**
+sonar.exclusions=./kraken-app/kraken-app-portal/src/__mocks__/**,./kraken-app/kraken-app-portal/src/__tests__/**,**/*.test.ts, **/*.test.tsx, ./kraken-app/kraken-app-portal/src/setupTests.tsx, **/*.d.ts, **/*.type.ts, **/*.type.tsx, ./kraken-app/kraken-app-portal/htmlTemplates/**
+sonar.javascript.lcov.reportPaths=./kraken-app/kraken-app-portal/coverage/lcov.info


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

1. create two projects in sonarcloud ( mono-repo)
2. integrate with sonar-cloud in the ci to report code coverage
