### PR TITLE
fix(sdk): fixed fqdn name query on ECS instances

### DIFF
--- a/kraken-java-sdk/kraken-java-sdk-core/src/main/java/com/consoleconnect/kraken/operator/core/toolkit/IpUtils.java
+++ b/kraken-java-sdk/kraken-java-sdk-core/src/main/java/com/consoleconnect/kraken/operator/core/toolkit/IpUtils.java
@@ -1,5 +1,8 @@
 package com.consoleconnect.kraken.operator.core.toolkit;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -53,9 +56,17 @@ public class IpUtils {
 
   public static String getFQDN() {
     try {
-      InetAddress address = InetAddress.getLocalHost();
-      return address.getCanonicalHostName();
-    } catch (UnknownHostException e) {
+      ProcessBuilder builder = new ProcessBuilder();
+      builder.command("bash", "-c", "hostname -f");
+      Process process = builder.start();
+      BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+      String line;
+      StringBuilder result = new StringBuilder();
+      while ((line = reader.readLine()) != null) {
+        result.append(line);
+      }
+      return result.toString();
+    } catch (IOException e) {
       return IP_UNKNOWN;
     }
   }

--- a/kraken-java-sdk/kraken-java-sdk-core/src/main/java/com/consoleconnect/kraken/operator/core/toolkit/IpUtils.java
+++ b/kraken-java-sdk/kraken-java-sdk-core/src/main/java/com/consoleconnect/kraken/operator/core/toolkit/IpUtils.java
@@ -57,7 +57,7 @@ public class IpUtils {
   public static String getFQDN() {
     try {
       ProcessBuilder builder = new ProcessBuilder();
-      builder.command("bash", "-c", "hostname -f");
+      builder.command("/usr/bin/bash", "-c", "hostname -f");
       Process process = builder.start();
       BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
       String line;

--- a/kraken-java-sdk/kraken-java-sdk-core/src/test/java/com/consoleconnect/kraken/operator/core/IpUtilsTest.java
+++ b/kraken-java-sdk/kraken-java-sdk-core/src/test/java/com/consoleconnect/kraken/operator/core/IpUtilsTest.java
@@ -16,4 +16,10 @@ class IpUtilsTest {
     String ip = IpUtils.getIP(request);
     Assertions.assertNotNull(ip);
   }
+
+  @Test
+  void givenECS_whenQueryFQDN_thenReturnSuccess() {
+    String result = IpUtils.getFQDN();
+    Assertions.assertNotEquals("unknown", result);
+  }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->
The method InetAddress.getLocalHost().getCanonicalHostName() returns the docker host name 'host.containers.internal ' instead of the ECS instance's host name.
## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- Please link to the issue here. -->
https://github.com/mycloudnexus/kraken/issues/244
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)
- [ ] CI/CD or documentation update (changes to CI/CD pipeline or documentation)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
