### PR TITLE
fix(portal): show tooltip on sonata predefined mapping api use cases

### DIFF
--- a/kraken-app/kraken-app-portal/src/pages/NewAPIMapping/components/RequestItem/SourceInput.tsx
+++ b/kraken-app/kraken-app-portal/src/pages/NewAPIMapping/components/RequestItem/SourceInput.tsx
@@ -1,13 +1,14 @@
 import { useNewApiMappingStore } from "@/stores/newApiMapping.store";
 import { EnumRightType } from "@/utils/types/common.type";
 import { IRequestMapping } from "@/utils/types/component.type";
-import { Flex, Tooltip } from "antd";
+import { Flex } from "antd";
 import clsx from "clsx";
 import { isEqual, cloneDeep, set } from "lodash";
 import { useMemo } from "react";
 import { LocationSelector } from "../LocationSelector";
 import styles from "./index.module.scss";
 import { AutoGrowingInput } from "@/components/form";
+import { Text } from "@/components/Text";
 
 export function SourceInput({
   item,
@@ -54,7 +55,12 @@ export function SourceInput({
         />
       ) : <div className={styles.bloater}></div>}
 
-      <Tooltip title={item.source}>
+      {!item.customizedField && (
+        <Text.LightMedium ellipsis
+          className={styles.requestMappingItemWrapper}
+          style={{ padding: 7 }}>{item.source}</Text.LightMedium>
+      )}
+      {item.customizedField && (
         <AutoGrowingInput
           data-testid="sourceInput"
           variant="filled"
@@ -87,7 +93,7 @@ export function SourceInput({
             }
           }}
         />
-      </Tooltip>
+      )}
     </Flex>
   );
 }

--- a/kraken-app/kraken-app-portal/src/pages/NewAPIMapping/components/ResponseItem/TargetInput.tsx
+++ b/kraken-app/kraken-app-portal/src/pages/NewAPIMapping/components/ResponseItem/TargetInput.tsx
@@ -1,7 +1,8 @@
 import { useNewApiMappingStore } from "@/stores/newApiMapping.store";
 import { EnumRightType } from "@/utils/types/common.type";
 import { IResponseMapping } from "@/utils/types/component.type";
-import { Flex, Tooltip } from "antd";
+import { Flex } from "antd";
+import { Text } from '@/components/Text'
 import clsx from "clsx";
 import { LocationSelector } from "../LocationSelector";
 import styles from "./index.module.scss";
@@ -40,7 +41,12 @@ export function TargetInput({
         />
       ) : <div className={styles.bloater}></div>}
 
-      <Tooltip title={item?.target}>
+      {!item.customizedField && (
+        <Text.LightMedium ellipsis
+          className={styles.input}
+          style={{ padding: 7, minHeight: 36, borderRadius: 4, width: '100%' }}>{item.target}</Text.LightMedium>
+      )}
+      {item.customizedField && (
         <AutoGrowingInput
           data-testid="targetInput"
           disabled={!item.customizedField}
@@ -61,7 +67,7 @@ export function TargetInput({
             // setActiveSonataResponse(undefined);
           }}
         />
-      </Tooltip>
+      )}
     </Flex>
   );
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

show tooltip on sonata predefined mapping api use cases

## Related Issue

- [[Improvement] All the properties from predefined mapping template should not be editable and shown as read-only form](https://github.com/mycloudnexus/kraken/issues/299)

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)
- [ ] CI/CD or documentation update (changes to CI/CD pipeline or documentation)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [x] I explained why this PR updates in detail with reasoning why it's required
- [x] I would like a code coverage CI quality gate exception and have explained why
