### PR TITLE
fix(sdk): removed product offering id for deleteing order

### DIFF
--- a/kraken-app/kraken-app-hub/src/test/resources/expected/expected-10-quote.uni.read.sync.json
+++ b/kraken-app/kraken-app-hub/src/test/resources/expected/expected-10-quote.uni.read.sync.json
@@ -15,5 +15,6 @@
   "externalId": "${entity.request[externalId]?:''}",
   "instantSyncQuote": "${entity.request[instantSyncQuote]?:''}",
   "requestedQuoteCompletionDate": "${entity.request[requestedQuoteCompletionDate]?:''}",
+  "quoteLevel": "${entity.request.quoteLevel}",
   "state": "${entity.renderedResponse.state}"
 }

--- a/kraken-app/kraken-app-hub/src/test/resources/expected/expected-7-quote.eline.read.json
+++ b/kraken-app/kraken-app-hub/src/test/resources/expected/expected-7-quote.eline.read.json
@@ -22,5 +22,6 @@
   "externalId": "${entity.request[externalId]?:''}",
   "instantSyncQuote": "${entity.request[instantSyncQuote]?:''}",
   "requestedQuoteCompletionDate": "${entity.request[requestedQuoteCompletionDate]?:''}",
+  "quoteLevel": "${entity.request.quoteLevel}",
   "state": "${entity.renderedResponse.state}"
 }

--- a/kraken-app/kraken-app-hub/src/test/resources/mock/api-targets-mappers/api-target-mapper.order.eline.delete.yaml
+++ b/kraken-app/kraken-app-hub/src/test/resources/mock/api-targets-mappers/api-target-mapper.order.eline.delete.yaml
@@ -36,15 +36,6 @@ spec:
             target: "@{{connectionId}}"
             targetLocation: ""
             requiredMapping: false
-          - name: mapper.order.uni.delete.productOffering.id
-            title: "id of a Product Offering"
-            description: ""
-            source: "@{{productOrderItem[0].product.productOffering.id}}"
-            sourceLocation: "BODY"
-            sourceType: string
-            target: "ACCESS_E_LINE"
-            targetLocation: ""
-            requiredMapping: true
         response:
           - name: mapper.order.eline.delete.state
             title: Order State Mapping

--- a/kraken-app/kraken-app-hub/src/test/resources/mock/api-targets-mappers/api-target-mapper.order.uni.delete.yaml
+++ b/kraken-app/kraken-app-hub/src/test/resources/mock/api-targets-mappers/api-target-mapper.order.uni.delete.yaml
@@ -35,15 +35,6 @@ spec:
             target: "@{{portId}}"
             targetLocation: PATH
             requiredMapping: false
-          - name: mapper.order.uni.delete.productOffering.id
-            title: "id of a Product Offering"
-            description: ""
-            source: "@{{productOrderItem[0].product.productOffering.id}}"
-            sourceLocation: "BODY"
-            sourceType: string
-            target: "UNI"
-            targetLocation: ""
-            requiredMapping: true
         response:
           - name: mapper.order.uni.delete.state
             title: Order State Mapping

--- a/kraken-app/kraken-app-hub/src/test/resources/mock/api-targets/api-target.quote.eline.read.sync.yaml
+++ b/kraken-app/kraken-app-hub/src/test/resources/mock/api-targets/api-target.quote.eline.read.sync.yaml
@@ -37,5 +37,6 @@ spec:
           "externalId":"${entity.request[externalId]?:''}",
           "instantSyncQuote":"${entity.request[instantSyncQuote]?:''}",
           "requestedQuoteCompletionDate": "${entity.request[requestedQuoteCompletionDate]?:''}",
+          "quoteLevel": "${entity.request.quoteLevel}",
           "state": "${entity.renderedResponse.state}"
         }

--- a/kraken-app/kraken-app-hub/src/test/resources/mock/api-targets/api-target.quote.eline.read.yaml
+++ b/kraken-app/kraken-app-hub/src/test/resources/mock/api-targets/api-target.quote.eline.read.yaml
@@ -43,5 +43,6 @@ spec:
           "externalId":"${entity.request[externalId]?:''}",
           "instantSyncQuote":"${entity.request[instantSyncQuote]?:''}",
           "requestedQuoteCompletionDate": "${entity.request[requestedQuoteCompletionDate]?:''}",
+          "quoteLevel": "${entity.request.quoteLevel}",
           "state": "${entity.renderedResponse.state}"
         }

--- a/kraken-app/kraken-app-hub/src/test/resources/mock/api-targets/api-target.quote.uni.read.sync.yaml
+++ b/kraken-app/kraken-app-hub/src/test/resources/mock/api-targets/api-target.quote.uni.read.sync.yaml
@@ -37,5 +37,6 @@ spec:
           "externalId":"${entity.request[externalId]?:''}",
           "instantSyncQuote":"${entity.request[instantSyncQuote]?:''}",
           "requestedQuoteCompletionDate": "${entity.request[requestedQuoteCompletionDate]?:''}",
+          "quoteLevel": "${entity.request.quoteLevel}",
           "state": "${entity.renderedResponse.state}"
         }

--- a/kraken-app/kraken-app-hub/src/test/resources/mock/api-targets/api-target.quote.uni.read.yaml
+++ b/kraken-app/kraken-app-hub/src/test/resources/mock/api-targets/api-target.quote.uni.read.yaml
@@ -43,5 +43,6 @@ spec:
          "externalId":"${entity.request[externalId]?:''}",
          "instantSyncQuote":"${entity.request[instantSyncQuote]?:''}",
          "requestedQuoteCompletionDate": "${entity.request[requestedQuoteCompletionDate]?:''}",
+         "quoteLevel": "${entity.request.quoteLevel}",
          "state": "${entity.renderedResponse.state}"
         }

--- a/kraken-java-sdk/kraken-java-sdk-mef/src/main/resources/mef-sonata/api-targets-mappers/api-target-mapper.order.eline.delete.yaml
+++ b/kraken-java-sdk/kraken-java-sdk-mef/src/main/resources/mef-sonata/api-targets-mappers/api-target-mapper.order.eline.delete.yaml
@@ -41,15 +41,6 @@ spec:
             target: ""
             targetLocation: ""
             requiredMapping: true
-          - name: mapper.order.uni.delete.productOffering.id
-            title: "id of a Product Offering"
-            description: ""
-            source: "@{{productOrderItem[0].product.productOffering.id}}"
-            sourceLocation: "BODY"
-            sourceType: string
-            target: ""
-            targetLocation: ""
-            requiredMapping: true
         response:
           - name: mapper.order.eline.delete.state
             title: "Order State"

--- a/kraken-java-sdk/kraken-java-sdk-mef/src/main/resources/mef-sonata/api-targets-mappers/api-target-mapper.order.uni.delete.yaml
+++ b/kraken-java-sdk/kraken-java-sdk-mef/src/main/resources/mef-sonata/api-targets-mappers/api-target-mapper.order.uni.delete.yaml
@@ -40,15 +40,6 @@ spec:
             target: ""
             targetLocation: ""
             requiredMapping: true
-          - name: mapper.order.uni.delete.productOffering.id
-            title: "id of a Product Offering"
-            description: ""
-            source: "@{{productOrderItem[0].product.productOffering.id}}"
-            sourceLocation: "BODY"
-            sourceType: string
-            target: ""
-            targetLocation: ""
-            requiredMapping: true
         response:
           - name: mapper.order.uni.delete.state
             title: "Order State"

--- a/kraken-java-sdk/kraken-java-sdk-mef/src/main/resources/mef-sonata/api-targets/api-target.quote.eline.read.sync.yaml
+++ b/kraken-java-sdk/kraken-java-sdk-mef/src/main/resources/mef-sonata/api-targets/api-target.quote.eline.read.sync.yaml
@@ -37,5 +37,6 @@ spec:
           "externalId":"${entity.request[externalId]?:''}",
           "instantSyncQuote":"${entity.request[instantSyncQuote]?:''}",
           "requestedQuoteCompletionDate": "${entity.request[requestedQuoteCompletionDate]?:''}",
+          "quoteLevel": "${entity.request.quoteLevel}",
           "state": "${entity.renderedResponse.state}"
         }

--- a/kraken-java-sdk/kraken-java-sdk-mef/src/main/resources/mef-sonata/api-targets/api-target.quote.eline.read.yaml
+++ b/kraken-java-sdk/kraken-java-sdk-mef/src/main/resources/mef-sonata/api-targets/api-target.quote.eline.read.yaml
@@ -43,5 +43,6 @@ spec:
           "externalId":"${entity.request[externalId]?:''}",
           "instantSyncQuote":"${entity.request[instantSyncQuote]?:''}",
           "requestedQuoteCompletionDate": "${entity.request[requestedQuoteCompletionDate]?:''}",
+          "quoteLevel": "${entity.request.quoteLevel}",
           "state": "${entity.renderedResponse.state}"
         }

--- a/kraken-java-sdk/kraken-java-sdk-mef/src/main/resources/mef-sonata/api-targets/api-target.quote.uni.read.sync.yaml
+++ b/kraken-java-sdk/kraken-java-sdk-mef/src/main/resources/mef-sonata/api-targets/api-target.quote.uni.read.sync.yaml
@@ -37,5 +37,6 @@ spec:
           "externalId":"${entity.request[externalId]?:''}",
           "instantSyncQuote":"${entity.request[instantSyncQuote]?:''}",
           "requestedQuoteCompletionDate": "${entity.request[requestedQuoteCompletionDate]?:''}",
+          "quoteLevel": "${entity.request.quoteLevel}",
           "state": "${entity.renderedResponse.state}"
         }

--- a/kraken-java-sdk/kraken-java-sdk-mef/src/main/resources/mef-sonata/api-targets/api-target.quote.uni.read.yaml
+++ b/kraken-java-sdk/kraken-java-sdk-mef/src/main/resources/mef-sonata/api-targets/api-target.quote.uni.read.yaml
@@ -43,5 +43,6 @@ spec:
          "externalId":"${entity.request[externalId]?:''}",
          "instantSyncQuote":"${entity.request[instantSyncQuote]?:''}",
          "requestedQuoteCompletionDate": "${entity.request[requestedQuoteCompletionDate]?:''}",
+         "quoteLevel": "${entity.request.quoteLevel}",
          "state": "${entity.renderedResponse.state}"
         }

--- a/kraken-java-sdk/kraken-java-sdk-mef/src/main/resources/mef-sonata/product.yaml
+++ b/kraken-java-sdk/kraken-java-sdk-mef/src/main/resources/mef-sonata/product.yaml
@@ -107,7 +107,7 @@ spec:
     - classpath:/mef-sonata/api-workflow/api-workflow.order.uni.delete.yaml
     - classpath:/mef-sonata/api-workflow/api-workflow.order.uni.add.yaml
     - classpath:/mef-sonata/api-workflow/api-workflow.order.eline.add.yaml
-    - classpath:/mef-sonata/template-upgrade/release.1.7.7.yaml
+    - classpath:/mef-sonata/template-upgrade/release.1.7.8.yaml
 
 
   templateUpgradePaths:

--- a/kraken-java-sdk/kraken-java-sdk-mef/src/main/resources/mef-sonata/template-upgrade/release.1.7.8.yaml
+++ b/kraken-java-sdk/kraken-java-sdk-mef/src/main/resources/mef-sonata/template-upgrade/release.1.7.8.yaml
@@ -1,0 +1,13 @@
+---
+kind: kraken.product.template-upgrade
+apiVersion: v1
+metadata:
+  key: kraken.product.template-upgrade.1.7.8
+  name: V1.7.8
+  labels:
+    productSpec: grace
+    productVersion: V1.7.8
+    publishDate: 2025-02-10
+  description: |
+    Add quote level for quote reading
+  version: 1

--- a/kraken-java-sdk/kraken-java-sdk-mef/src/main/resources/mef-sonata/template-upgrade/release.1.7.8.yaml
+++ b/kraken-java-sdk/kraken-java-sdk-mef/src/main/resources/mef-sonata/template-upgrade/release.1.7.8.yaml
@@ -10,4 +10,5 @@ metadata:
     publishDate: 2025-02-10
   description: |
     Add quote level for quote reading
+    Removed 'productOrderItem[0].product.productOffering.id' in the mapper for deleting order
   version: 1


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->
1. Removed 'productOrderItem[0].product.productOffering.id' in the mapper for deleting order;
2. Added 'qouteLevel' for quote reading;
## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- Please link to the issue here. -->
https://github.com/mycloudnexus/kraken/issues/413
https://github.com/mycloudnexus/kraken/issues/432
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)
- [ ] CI/CD or documentation update (changes to CI/CD pipeline or documentation)

## Self Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [x] I ensured that I are not pushing configuration files containing sensitive information such as testing keys.
- [x] I ensured that large PR is avoided,  Consider splitting if there are more than 500 line changes, In addition to line count, also consider the number of files being affected, An ideal amount is less than 10, 25-30 is generally too large with the exception of library upgrades, refactors, etc.
- [x] I ensured that If the PR is inevitably large, a short PR review meeting or discuss with reviewers will be organized.
- [x] I ensured that If the PR is to resolve a blocker, do not make unrelated changes in the same PR e.g. formatting changes, to minimize review time.
- [x] I ensured that PR is focused
- [x] I ensured that context was given in the PR description, Include a clear description of the changes
- [x] I ensured that related github issues are linked, Include screenshots if this will make the context clearer for the reviewer
- [x] I ensured that "work in progress" or "hold" labels are removed
- [x] I ensured that adherence to style guidelines
- [x] I ensured that feature flag is applied if needed
- [x] I ensured that follow secure development practices
- [x] I ensured that no secrets or sensitive data have been committed or logged
- [x] I ensured that no hardcoded values that may change depending on environment (these should be configured dynamically e.g. through environment variables, from the db etc)
