### PR TITLE
fix(sdk): resolved exception while two records share the same instance id

### DIFF
--- a/kraken-java-sdk/kraken-java-sdk-gateway/src/main/java/com/consoleconnect/kraken/operator/gateway/repo/HttpRequestRepository.java
+++ b/kraken-java-sdk/kraken-java-sdk-gateway/src/main/java/com/consoleconnect/kraken/operator/gateway/repo/HttpRequestRepository.java
@@ -2,7 +2,6 @@ package com.consoleconnect.kraken.operator.gateway.repo;
 
 import com.consoleconnect.kraken.operator.gateway.entity.HttpRequestEntity;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -18,7 +17,7 @@ public interface HttpRequestRepository
         JpaSpecificationExecutor<HttpRequestEntity> {
   List<HttpRequestEntity> findByExternalId(String externalId);
 
-  Optional<HttpRequestEntity> findByProductInstanceId(String productInstanceId);
+  List<HttpRequestEntity> findByProductInstanceId(String productInstanceId);
 
   @Query(
       value =

--- a/kraken-java-sdk/kraken-java-sdk-gateway/src/main/java/com/consoleconnect/kraken/operator/gateway/runner/DBCrudActionRunner.java
+++ b/kraken-java-sdk/kraken-java-sdk-gateway/src/main/java/com/consoleconnect/kraken/operator/gateway/runner/DBCrudActionRunner.java
@@ -194,7 +194,7 @@ public class DBCrudActionRunner extends AbstractActionRunner {
       }
       return repository.findById(entityUUID);
     }
-    return repository.findByProductInstanceId(entityId);
+    return repository.findByProductInstanceId(entityId).stream().findAny();
   }
 
   @Data

--- a/kraken-java-sdk/kraken-java-sdk-gateway/src/test/java/com/consoleconnect/kraken/operator/gateway/runner/DBCrudActionRunnerTest.java
+++ b/kraken-java-sdk/kraken-java-sdk-gateway/src/test/java/com/consoleconnect/kraken/operator/gateway/runner/DBCrudActionRunnerTest.java
@@ -9,6 +9,7 @@ import com.consoleconnect.kraken.operator.gateway.repo.HttpRequestRepository;
 import com.consoleconnect.kraken.operator.test.AbstractIntegrationTest;
 import com.consoleconnect.kraken.operator.test.MockIntegrationTest;
 import java.util.*;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
@@ -68,6 +69,18 @@ class DBCrudActionRunnerTest extends AbstractIntegrationTest {
     entity.setBizType("db persist");
     httpRequestRepository.save(entity);
 
+    DBCrudActionRunner.Config configUpdate = getConfig(entity, DBActionTypeEnum.UPDATE);
+    exchange.getAttributes().put(KrakenFilterConstants.X_ENTITY_ID, entity.getId().toString());
+    Assertions.assertDoesNotThrow(() -> dbCrudActionRunner.onPersist(exchange, configUpdate));
+
+    DBCrudActionRunner.Config configRead = getConfig(entity, DBActionTypeEnum.READ);
+    configRead.setActionField("productInstanceId");
+    configRead.setId("67ad55a4d3044d46e53dc5ab");
+    Assertions.assertDoesNotThrow(() -> dbCrudActionRunner.onPersist(exchange, configRead));
+  }
+
+  private static DBCrudActionRunner.@NotNull Config getConfig(
+      HttpRequestEntity entity, DBActionTypeEnum actionType) {
     DBCrudActionRunner.Config config = new DBCrudActionRunner.Config();
     Map<String, String> env = new HashMap<>();
     env.put("productInstanceId", "${renderedResponseBody[0].id?:''}");
@@ -79,9 +92,8 @@ class DBCrudActionRunnerTest extends AbstractIntegrationTest {
     properties.add("renderedResponseBody");
     config.setProperties(properties);
     config.setId(entity.getId().toString());
-    config.setAction(DBActionTypeEnum.UPDATE);
-    exchange.getAttributes().put(KrakenFilterConstants.X_ENTITY_ID, entity.getId().toString());
-    Assertions.assertDoesNotThrow(() -> dbCrudActionRunner.onPersist(exchange, config));
+    config.setAction(actionType);
+    return config;
   }
 
   @Test


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->
An exception occurred while routing the inventory read because the 'add' and 'delete' operations share the same product instance ID.
This PR has resolve the above issue.
## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- Please link to the issue here. -->
https://github.com/mycloudnexus/kraken/issues/508
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested
Unit test only
<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)
- [ ] CI/CD or documentation update (changes to CI/CD pipeline or documentation)

## Self Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [x] I ensured that I are not pushing configuration files containing sensitive information such as testing keys.
- [x] I ensured that large PR is avoided,  Consider splitting if there are more than 500 line changes, In addition to line count, also consider the number of files being affected, An ideal amount is less than 10, 25-30 is generally too large with the exception of library upgrades, refactors, etc.
- [x] I ensured that If the PR is inevitably large, a short PR review meeting or discuss with reviewers will be organized.
- [x] I ensured that If the PR is to resolve a blocker, do not make unrelated changes in the same PR e.g. formatting changes, to minimize review time.
- [x] I ensured that PR is focused
- [x] I ensured that context was given in the PR description, Include a clear description of the changes
- [x] I ensured that related github issues are linked, Include screenshots if this will make the context clearer for the reviewer
- [x] I ensured that "work in progress" or "hold" labels are removed
- [x] I ensured that adherence to style guidelines
- [x] I ensured that feature flag is applied if needed
- [x] I ensured that follow secure development practices
- [x] I ensured that no secrets or sensitive data have been committed or logged
- [x] I ensured that no hardcoded values that may change depending on environment (these should be configured dynamically e.g. through environment variables, from the db etc)
