### PR TITLE
feat(sdk): issues-593 support workflow template merge when upgrade template

### DIFF
--- a/kraken-java-sdk/kraken-java-sdk-core/src/main/java/com/consoleconnect/kraken/operator/core/service/UnifiedAssetService.java
+++ b/kraken-java-sdk/kraken-java-sdk-core/src/main/java/com/consoleconnect/kraken/operator/core/service/UnifiedAssetService.java
@@ -365,7 +365,14 @@ public class UnifiedAssetService implements UUIDWrapper {
       return;
     }
 
-    stageTasksNew.get(0).setConditionCheck(stageTasksOld.get(0).getConditionCheck());
+    HttpTask.ConditionCheck oldConditionCheck = stageTasksOld.get(0).getConditionCheck();
+    HttpTask.ConditionCheck newConditionCheck = stageTasksNew.get(0).getConditionCheck();
+    if (oldConditionCheck != null
+        && newConditionCheck != null
+        && newConditionCheck.getBuildInTask() != null) {
+      oldConditionCheck.setBuildInTask(newConditionCheck.getBuildInTask());
+    }
+    stageTasksNew.get(0).setConditionCheck(oldConditionCheck);
 
     ComponentAPITargetFacets.Endpoint endpointOld = stageTasksOld.get(0).getEndpoint();
     ComponentAPITargetFacets.Endpoint endpointNew = stageTasksNew.get(0).getEndpoint();

--- a/kraken-java-sdk/kraken-java-sdk-core/src/main/java/com/consoleconnect/kraken/operator/core/service/UnifiedAssetService.java
+++ b/kraken-java-sdk/kraken-java-sdk-core/src/main/java/com/consoleconnect/kraken/operator/core/service/UnifiedAssetService.java
@@ -1,6 +1,7 @@
 package com.consoleconnect.kraken.operator.core.service;
 
 import static com.consoleconnect.kraken.operator.core.enums.AssetKindEnum.COMPONENT_API_TARGET_MAPPER;
+import static com.consoleconnect.kraken.operator.core.enums.AssetKindEnum.COMPONENT_API_WORK_FLOW;
 import static com.consoleconnect.kraken.operator.core.toolkit.LabelConstants.FUNCTION_JSON_EXTRACT_PATH_TEXT;
 
 import com.consoleconnect.kraken.operator.core.dto.AssetLinkDto;
@@ -16,6 +17,7 @@ import com.consoleconnect.kraken.operator.core.mapper.AssetMapper;
 import com.consoleconnect.kraken.operator.core.mapper.FacetsMapper;
 import com.consoleconnect.kraken.operator.core.model.*;
 import com.consoleconnect.kraken.operator.core.model.facet.ComponentAPITargetFacets;
+import com.consoleconnect.kraken.operator.core.model.facet.ComponentWorkflowFacets;
 import com.consoleconnect.kraken.operator.core.repo.AssetFacetRepository;
 import com.consoleconnect.kraken.operator.core.repo.AssetLinkRepository;
 import com.consoleconnect.kraken.operator.core.repo.UnifiedAssetRepository;
@@ -299,8 +301,7 @@ public class UnifiedAssetService implements UUIDWrapper {
 
     log.info("syncing asset facets, assetId: {}", assetEntity.getKey());
 
-    if (Objects.equals(assetEntity.getKind(), COMPONENT_API_TARGET_MAPPER.getKind())
-        && entityOptional.isPresent()) {
+    if (enableMerge(assetEntity) && entityOptional.isPresent()) {
       data.setFacets(mergeService.mergeFacets(entityOptional.get(), data.getFacets()));
     }
     if (data.getFacets() != null) {
@@ -324,6 +325,11 @@ public class UnifiedAssetService implements UUIDWrapper {
     return IngestionDataResult.of(HttpStatus.OK.value(), "Asset synced", assetEntity);
   }
 
+  private boolean enableMerge(UnifiedAssetEntity assetEntity) {
+    return Objects.equals(assetEntity.getKind(), COMPONENT_API_TARGET_MAPPER.getKind())
+        || Objects.equals(assetEntity.getKind(), COMPONENT_API_WORK_FLOW.getKind());
+  }
+
   private String getParentId(String parentKey) {
     return parentKey == null ? null : findOneByIdOrKey(parentKey).getId().toString();
   }
@@ -331,17 +337,52 @@ public class UnifiedAssetService implements UUIDWrapper {
   public static Map<String, Object> mergeFacets(
       UnifiedAssetEntity unifiedAssetEntity, Map<String, Object> facetsUpdated) {
     UnifiedAssetDto assetDto = UnifiedAssetService.toAsset(unifiedAssetEntity, true);
-    ComponentAPITargetFacets existFacets =
-        UnifiedAsset.getFacets(assetDto, ComponentAPITargetFacets.class);
-    ComponentAPITargetFacets newFacets =
-        JsonToolkit.fromJson(JsonToolkit.toJson(facetsUpdated), ComponentAPITargetFacets.class);
-    return mergeFacets(existFacets, newFacets);
+    if (Objects.equals(unifiedAssetEntity.getKind(), COMPONENT_API_TARGET_MAPPER.getKind())) {
+      ComponentAPITargetFacets existFacets =
+          UnifiedAsset.getFacets(assetDto, ComponentAPITargetFacets.class);
+      ComponentAPITargetFacets newFacets =
+          JsonToolkit.fromJson(JsonToolkit.toJson(facetsUpdated), ComponentAPITargetFacets.class);
+      return mergeFacets(existFacets, newFacets);
+    } else {
+      ComponentWorkflowFacets existFacets =
+          UnifiedAsset.getFacets(assetDto, ComponentWorkflowFacets.class);
+      ComponentWorkflowFacets newFacets =
+          JsonToolkit.fromJson(JsonToolkit.toJson(facetsUpdated), ComponentWorkflowFacets.class);
+      return mergeFacets(existFacets, newFacets);
+    }
+  }
+
+  private static Map<String, Object> mergeFacets(
+      ComponentWorkflowFacets facetsOld, ComponentWorkflowFacets facetsNew) {
+    mergeFacets(facetsOld.getValidationStage(), facetsNew.getValidationStage());
+    mergeFacets(facetsOld.getPreparationStage(), facetsNew.getPreparationStage());
+    mergeFacets(facetsOld.getExecutionStage(), facetsNew.getExecutionStage());
+    return JsonToolkit.fromJson(JsonToolkit.toJson(facetsNew), new TypeReference<>() {});
+  }
+
+  private static void mergeFacets(List<HttpTask> stageTasksOld, List<HttpTask> stageTasksNew) {
+    if (CollectionUtils.isEmpty(stageTasksOld) || CollectionUtils.isEmpty(stageTasksNew)) {
+      return;
+    }
+
+    stageTasksNew.get(0).setConditionCheck(stageTasksOld.get(0).getConditionCheck());
+
+    ComponentAPITargetFacets.Endpoint endpointOld = stageTasksOld.get(0).getEndpoint();
+    ComponentAPITargetFacets.Endpoint endpointNew = stageTasksNew.get(0).getEndpoint();
+    mergeEndpoint(endpointOld, endpointNew);
   }
 
   public static Map<String, Object> mergeFacets(
       ComponentAPITargetFacets facetsOld, ComponentAPITargetFacets facetsNew) {
     ComponentAPITargetFacets.Endpoint endpointOld = facetsOld.getEndpoints().get(0);
     ComponentAPITargetFacets.Endpoint endpointNew = facetsNew.getEndpoints().get(0);
+    mergeEndpoint(endpointOld, endpointNew);
+    return JsonToolkit.fromJson(JsonToolkit.toJson(facetsNew), new TypeReference<>() {});
+  }
+
+  public static void mergeEndpoint(
+      ComponentAPITargetFacets.Endpoint endpointOld,
+      ComponentAPITargetFacets.Endpoint endpointNew) {
     List<PathRule> pathRules =
         (Objects.isNull(endpointNew) || Objects.isNull(endpointNew.getMappers()))
             ? new ArrayList<>()
@@ -362,7 +403,6 @@ public class UnifiedAssetService implements UUIDWrapper {
     if (Objects.nonNull(endpointNew)) {
       endpointNew.setMappers(mappers);
     }
-    return JsonToolkit.fromJson(JsonToolkit.toJson(facetsNew), new TypeReference<>() {});
   }
 
   public static void mergeMappers(

--- a/kraken-java-sdk/kraken-java-sdk-core/src/test/java/com/consoleconnect/kraken/operator/core/service/UnifiedAssetServiceTest.java
+++ b/kraken-java-sdk/kraken-java-sdk-core/src/test/java/com/consoleconnect/kraken/operator/core/service/UnifiedAssetServiceTest.java
@@ -14,9 +14,11 @@ import com.consoleconnect.kraken.operator.core.entity.UnifiedAssetEntity;
 import com.consoleconnect.kraken.operator.core.enums.AssetKindEnum;
 import com.consoleconnect.kraken.operator.core.enums.AssetStatusEnum;
 import com.consoleconnect.kraken.operator.core.event.IngestionDataResult;
+import com.consoleconnect.kraken.operator.core.model.HttpTask;
 import com.consoleconnect.kraken.operator.core.model.SyncMetadata;
 import com.consoleconnect.kraken.operator.core.model.UnifiedAsset;
 import com.consoleconnect.kraken.operator.core.model.facet.ComponentAPITargetFacets;
+import com.consoleconnect.kraken.operator.core.model.facet.ComponentWorkflowFacets;
 import com.consoleconnect.kraken.operator.core.toolkit.*;
 import com.consoleconnect.kraken.operator.test.AbstractIntegrationTest;
 import com.consoleconnect.kraken.operator.test.MockIntegrationTest;
@@ -32,6 +34,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.util.CollectionUtils;
 
 @Slf4j
 @MockIntegrationTest
@@ -39,6 +42,8 @@ import org.springframework.test.context.ContextConfiguration;
 class UnifiedAssetServiceTest extends AbstractIntegrationTest {
 
   @Autowired private UnifiedAssetService unifiedAssetService;
+
+  @Autowired private MergeService mergeService;
 
   private static final String MAPPER_REQUEST = "request";
 
@@ -179,7 +184,7 @@ class UnifiedAssetServiceTest extends AbstractIntegrationTest {
 
   @SneakyThrows
   @Test
-  void givenSourceValues_whenMerge_thenReturnOK() {
+  void givenSourceValues_whenMergeApiMappers_thenReturnOK() {
     String s1 = readFileToString("data/mapper_old.json");
     Map<String, Map<String, ComponentAPITargetFacets.Mapper>> existMapperMap =
         JsonToolkit.fromJson(s1, new TypeReference<>() {});
@@ -298,6 +303,59 @@ class UnifiedAssetServiceTest extends AbstractIntegrationTest {
         "mapper.testcase06.mergeSystemToCustomizedMapping", newMapperMap, expectedResults);
   }
 
+  @Test
+  void givenSourceValues_whenMergeApiWorkflows_thenReturnOK() {
+    UnifiedAsset assetOld = loadAsset("data/workflow_old.yaml");
+    UnifiedAsset assetNew = loadAsset("data/workflow_new.yaml");
+    UnifiedAsset expectedMerged = loadAsset("data/workflow_merged.yaml");
+
+    IngestionDataResult ingestionDataResult =
+        unifiedAssetService.syncAsset(
+            "product.mef.sonata.api",
+            assetOld,
+            new SyncMetadata("", "", DateTime.nowInUTCString(), ""),
+            true);
+    UnifiedAssetEntity assetEntity = ingestionDataResult.getData();
+    Map<String, Object> result = UnifiedAssetService.mergeFacets(assetEntity, assetNew.getFacets());
+    verifyWorkflow(result, expectedMerged.getFacets());
+  }
+
+  private void verifyWorkflow(Map<String, Object> actual, Map<String, Object> expected) {
+    ComponentWorkflowFacets actualFacets =
+        JsonToolkit.fromJson(JsonToolkit.toJson(actual), ComponentWorkflowFacets.class);
+    ComponentWorkflowFacets expectedFacets =
+        JsonToolkit.fromJson(JsonToolkit.toJson(expected), ComponentWorkflowFacets.class);
+    verifyMergedTask(
+        actualFacets.getValidationStage().get(0), expectedFacets.getValidationStage().get(0));
+    verifyMergedTask(
+        actualFacets.getPreparationStage().get(0), expectedFacets.getPreparationStage().get(0));
+    verifyMergedTask(
+        actualFacets.getExecutionStage().get(0), expectedFacets.getExecutionStage().get(0));
+  }
+
+  private void verifyMergedTask(HttpTask actualTask, HttpTask expectedTask) {
+    Assertions.assertEquals(expectedTask.getTaskName(), actualTask.getTaskName());
+    Assertions.assertEquals(expectedTask.getTaskType(), actualTask.getTaskType());
+    Assertions.assertEquals(expectedTask.getNotificationUrl(), actualTask.getNotificationUrl());
+
+    verifyMergedMapper(
+        actualTask.getEndpoint().getMappers().getRequest().get(0),
+        expectedTask.getEndpoint().getMappers().getRequest().get(0));
+
+    Assertions.assertEquals(
+        expectedTask.getConditionCheck().getJoin(), actualTask.getConditionCheck().getJoin());
+    if (!CollectionUtils.isEmpty(expectedTask.getConditionCheck().getConditionItems())) {
+      Assertions.assertEquals(
+          expectedTask.getConditionCheck().getConditionItems().get(0).getExpression(),
+          actualTask.getConditionCheck().getConditionItems().get(0).getExpression());
+    }
+  }
+
+  @SneakyThrows
+  private UnifiedAsset loadAsset(String path) {
+    return YamlToolkit.parseYaml(readFileToString(path), UnifiedAsset.class).get();
+  }
+
   private void verifyDeletedMapper(
       String testcase, Map<String, Map<String, ComponentAPITargetFacets.Mapper>> mergedMapperMap) {
     verifyDeletedMapper(mergedMapperMap, testcase, MAPPER_REQUEST);
@@ -329,6 +387,12 @@ class UnifiedAssetServiceTest extends AbstractIntegrationTest {
     ComponentAPITargetFacets.Mapper mergedMapper = mergedMapperMap.get(fullName).get(mapperSection);
     ComponentAPITargetFacets.Mapper expectedMapper =
         expectedMapperMap.get(fullName).get(mapperSection);
+    verifyMergedMapper(mergedMapper, expectedMapper);
+  }
+
+  private void verifyMergedMapper(
+      ComponentAPITargetFacets.Mapper mergedMapper,
+      ComponentAPITargetFacets.Mapper expectedMapper) {
     Assertions.assertEquals(expectedMapper.getTitle(), mergedMapper.getTitle());
     Assertions.assertEquals(expectedMapper.getName(), mergedMapper.getName());
     Assertions.assertEquals(expectedMapper.getDescription(), mergedMapper.getDescription());
@@ -377,8 +441,10 @@ class UnifiedAssetServiceTest extends AbstractIntegrationTest {
 
       String result1 = JsonToolkit.toJson(facetsOld);
       Assertions.assertNotNull(result1);
-      Map<String, Object> map = UnifiedAssetService.mergeFacets(facetsOld, facetsNew);
-      String result2 = JsonToolkit.toJson(map);
+      ComponentAPITargetFacets.Endpoint endpointOld = facetsOld.getEndpoints().get(0);
+      ComponentAPITargetFacets.Endpoint endpointNew = facetsNew.getEndpoints().get(0);
+      UnifiedAssetService.mergeEndpoint(endpointOld, endpointNew);
+      String result2 = JsonToolkit.toJson(facetsNew);
       Assertions.assertNotNull(result2);
       assertThat(result2, hasJsonPath("$.endpoints[0].mappers.request", hasSize(9)));
       assertThat(result2, hasJsonPath("$.endpoints[0].mappers.response", hasSize(10)));

--- a/kraken-java-sdk/kraken-java-sdk-core/src/test/java/com/consoleconnect/kraken/operator/core/service/UnifiedAssetServiceTest.java
+++ b/kraken-java-sdk/kraken-java-sdk-core/src/test/java/com/consoleconnect/kraken/operator/core/service/UnifiedAssetServiceTest.java
@@ -344,6 +344,9 @@ class UnifiedAssetServiceTest extends AbstractIntegrationTest {
 
     Assertions.assertEquals(
         expectedTask.getConditionCheck().getJoin(), actualTask.getConditionCheck().getJoin());
+    Assertions.assertEquals(
+        expectedTask.getConditionCheck().getBuildInTask(),
+        actualTask.getConditionCheck().getBuildInTask());
     if (!CollectionUtils.isEmpty(expectedTask.getConditionCheck().getConditionItems())) {
       Assertions.assertEquals(
           expectedTask.getConditionCheck().getConditionItems().get(0).getExpression(),

--- a/kraken-java-sdk/kraken-java-sdk-core/src/test/resources/data/workflow_merged.yaml
+++ b/kraken-java-sdk/kraken-java-sdk-core/src/test/resources/data/workflow_merged.yaml
@@ -1,0 +1,95 @@
+---
+kind: kraken.component.api-workflow
+apiVersion: v1
+metadata:
+  key: mef.sonata.api-workflow.order.eline.delete
+  name: Order Management
+  version: 1
+spec:
+  metaData:
+    workflowName: "order.eline.delete"
+    externalId: ""
+  validationStage:
+    - taskName: status_checking_task_new
+      taskType: https
+      notificationUrl: http://slack.notice/api-new
+      endpoint:
+        path: "/api/v2/company/{username}/connections/{connectionId}"
+        method: GET
+        serverKey: ''
+        mappers:
+          request:
+            - name: mapper.order.eline.delete.buyerId
+              title: "The unique identifier of the organization that is acting as the a Buyer."
+              description: ""
+              source: "@{{buyerId}}"
+              sourceLocation: "QUERY"
+              target: "@{{username-old}}"
+              targetLocation: "PATH"
+              requiredMapping: false
+            - name: mapper.order.eline.delete.productId
+              title: "The unique identifier of an in-service Product that is the ordering subject"
+              description: ""
+              source: "@{{productOrderItem[*].product.id}}"
+              sourceLocation: "BODY"
+              target: "@{{connectionId}}"
+              targetLocation: "PATH"
+              requiredMapping: true
+      conditionCheck:
+        join: OR
+        conditionItems:
+          - operator: EQUAL
+            value: "DELETED"
+            expression: "status_checking_task.status-old"
+        buildInTask: reject_order_task
+  preparationStage:
+    - taskName: disable_order_task
+      taskType: http
+      endpoint:
+        path: "/api/company/{companyName}/connections/{connectionId}/disable"
+        method: PUT
+        serverKey: ''
+        mappers:
+          request:
+            - name: mapper.order.eline.delete.buyerId
+              title: "The unique identifier of the organization that is acting as the a Buyer."
+              description: ""
+              source: "@{{buyerId}}"
+              sourceLocation: "QUERY"
+              target: "@{{companyName}}"
+              targetLocation: "PATH"
+              requiredMapping: false
+            - name: mapper.order.eline.delete.productId
+              title: "The unique identifier of an in-service Product that is the ordering subject"
+              description: ""
+              source: "@{{productOrderItem[*].product.id}}"
+              sourceLocation: "BODY"
+              target: "@{{connectionId}}"
+              targetLocation: "PATH"
+              requiredMapping: true
+  executionStage:
+    - taskName: delete_order_task
+      taskType: http
+      endpoint:
+        path: "/api/v2/company/{username}/connections/{connectionId}"
+        method: 'DELETE'
+        serverKey: ''
+        mappers:
+          request:
+            - name: mapper.order.eline.delete.buyerId
+              title: "The unique identifier of the organization that is acting as the a Buyer."
+              description: ""
+              source: "@{{buyerId}}"
+              sourceLocation: "QUERY"
+              target: "@{{username}}"
+              targetLocation: "PATH"
+              requiredMapping: false
+            - name: mapper.order.eline.delete.productId
+              title: "The unique identifier of an in-service Product that is the ordering subject"
+              description: ""
+              source: "@{{productOrderItem[*].product.id}}"
+              sourceLocation: "BODY"
+              target: "@{{connectionId}}"
+              targetLocation: "PATH"
+              requiredMapping: true
+      notificationUrl: http://slack.notice/api

--- a/kraken-java-sdk/kraken-java-sdk-core/src/test/resources/data/workflow_merged.yaml
+++ b/kraken-java-sdk/kraken-java-sdk-core/src/test/resources/data/workflow_merged.yaml
@@ -41,7 +41,7 @@ spec:
           - operator: EQUAL
             value: "DELETED"
             expression: "status_checking_task.status-old"
-        buildInTask: reject_order_task
+        buildInTask: reject_order_task_new
   preparationStage:
     - taskName: disable_order_task
       taskType: http

--- a/kraken-java-sdk/kraken-java-sdk-core/src/test/resources/data/workflow_new.yaml
+++ b/kraken-java-sdk/kraken-java-sdk-core/src/test/resources/data/workflow_new.yaml
@@ -1,0 +1,95 @@
+---
+kind: kraken.component.api-workflow
+apiVersion: v1
+metadata:
+  key: mef.sonata.api-workflow.order.eline.delete
+  name: Order Management
+  version: 1
+spec:
+  metaData:
+    workflowName: "order.eline.delete"
+    externalId: ""
+  validationStage:
+    - taskName: status_checking_task_new
+      taskType: https
+      notificationUrl: http://slack.notice/api-new
+      endpoint:
+        path: "/api/v2/company/{username}/connections/{connectionId}"
+        method: GET
+        serverKey: ''
+        mappers:
+          request:
+            - name: mapper.order.eline.delete.buyerId
+              title: "The unique identifier of the organization that is acting as the a Buyer."
+              description: ""
+              source: "@{{buyerId}}"
+              sourceLocation: "QUERY"
+              target: "@{{username-new}}"
+              targetLocation: "PATH"
+              requiredMapping: false
+            - name: mapper.order.eline.delete.productId
+              title: "The unique identifier of an in-service Product that is the ordering subject"
+              description: ""
+              source: "@{{productOrderItem[*].product.id}}"
+              sourceLocation: "BODY"
+              target: "@{{connectionId}}"
+              targetLocation: "PATH"
+              requiredMapping: true
+      conditionCheck:
+        join: AND
+        conditionItems:
+          - operator: EQUAL
+            value: "DELETED"
+            expression: "status_checking_task.status-new"
+        buildInTask: reject_order_task
+  preparationStage:
+    - taskName: disable_order_task
+      taskType: http
+      endpoint:
+        path: "/api/company/{companyName}/connections/{connectionId}/disable"
+        method: PUT
+        serverKey: ''
+        mappers:
+          request:
+            - name: mapper.order.eline.delete.buyerId
+              title: "The unique identifier of the organization that is acting as the a Buyer."
+              description: ""
+              source: "@{{buyerId}}"
+              sourceLocation: "QUERY"
+              target: "@{{companyName}}"
+              targetLocation: "PATH"
+              requiredMapping: false
+            - name: mapper.order.eline.delete.productId
+              title: "The unique identifier of an in-service Product that is the ordering subject"
+              description: ""
+              source: "@{{productOrderItem[*].product.id}}"
+              sourceLocation: "BODY"
+              target: "@{{connectionId}}"
+              targetLocation: "PATH"
+              requiredMapping: true
+  executionStage:
+    - taskName: delete_order_task
+      taskType: http
+      endpoint:
+        path: "/api/v2/company/{username}/connections/{connectionId}"
+        method: 'DELETE'
+        serverKey: ''
+        mappers:
+          request:
+            - name: mapper.order.eline.delete.buyerId
+              title: "The unique identifier of the organization that is acting as the a Buyer."
+              description: ""
+              source: "@{{buyerId}}"
+              sourceLocation: "QUERY"
+              target: "@{{username}}"
+              targetLocation: "PATH"
+              requiredMapping: false
+            - name: mapper.order.eline.delete.productId
+              title: "The unique identifier of an in-service Product that is the ordering subject"
+              description: ""
+              source: "@{{productOrderItem[*].product.id}}"
+              sourceLocation: "BODY"
+              target: "@{{connectionId}}"
+              targetLocation: "PATH"
+              requiredMapping: true
+      notificationUrl: http://slack.notice/api

--- a/kraken-java-sdk/kraken-java-sdk-core/src/test/resources/data/workflow_new.yaml
+++ b/kraken-java-sdk/kraken-java-sdk-core/src/test/resources/data/workflow_new.yaml
@@ -41,7 +41,7 @@ spec:
           - operator: EQUAL
             value: "DELETED"
             expression: "status_checking_task.status-new"
-        buildInTask: reject_order_task
+        buildInTask: reject_order_task_new
   preparationStage:
     - taskName: disable_order_task
       taskType: http

--- a/kraken-java-sdk/kraken-java-sdk-core/src/test/resources/data/workflow_old.yaml
+++ b/kraken-java-sdk/kraken-java-sdk-core/src/test/resources/data/workflow_old.yaml
@@ -41,7 +41,7 @@ spec:
           - operator: EQUAL
             value: "DELETED"
             expression: "status_checking_task.status-old"
-        buildInTask: reject_order_task
+        buildInTask: reject_order_task_old
   preparationStage:
     - taskName: disable_order_task
       taskType: http

--- a/kraken-java-sdk/kraken-java-sdk-core/src/test/resources/data/workflow_old.yaml
+++ b/kraken-java-sdk/kraken-java-sdk-core/src/test/resources/data/workflow_old.yaml
@@ -1,0 +1,95 @@
+---
+kind: kraken.component.api-workflow
+apiVersion: v1
+metadata:
+  key: mef.sonata.api-workflow.order.eline.delete
+  name: Order Management
+  version: 1
+spec:
+  metaData:
+    workflowName: "order.eline.delete"
+    externalId: ""
+  validationStage:
+    - taskName: status_checking_task_old
+      taskType: http
+      notificationUrl: http://slack.notice/api-old
+      endpoint:
+        path: "/api/v2/company/{username}/connections/{connectionId}"
+        method: GET
+        serverKey: ''
+        mappers:
+          request:
+            - name: mapper.order.eline.delete.buyerId
+              title: "The unique identifier of the organization that is acting as the a Buyer."
+              description: ""
+              source: "@{{buyerId}}"
+              sourceLocation: "QUERY"
+              target: "@{{username-old}}"
+              targetLocation: "PATH"
+              requiredMapping: false
+            - name: mapper.order.eline.delete.productId
+              title: "The unique identifier of an in-service Product that is the ordering subject"
+              description: ""
+              source: "@{{productOrderItem[*].product.id}}"
+              sourceLocation: "BODY"
+              target: "@{{connectionId}}"
+              targetLocation: "PATH"
+              requiredMapping: true
+      conditionCheck:
+        join: OR
+        conditionItems:
+          - operator: EQUAL
+            value: "DELETED"
+            expression: "status_checking_task.status-old"
+        buildInTask: reject_order_task
+  preparationStage:
+    - taskName: disable_order_task
+      taskType: http
+      endpoint:
+        path: "/api/company/{companyName}/connections/{connectionId}/disable"
+        method: PUT
+        serverKey: ''
+        mappers:
+          request:
+            - name: mapper.order.eline.delete.buyerId
+              title: "The unique identifier of the organization that is acting as the a Buyer."
+              description: ""
+              source: "@{{buyerId}}"
+              sourceLocation: "QUERY"
+              target: "@{{companyName}}"
+              targetLocation: "PATH"
+              requiredMapping: false
+            - name: mapper.order.eline.delete.productId
+              title: "The unique identifier of an in-service Product that is the ordering subject"
+              description: ""
+              source: "@{{productOrderItem[*].product.id}}"
+              sourceLocation: "BODY"
+              target: "@{{connectionId}}"
+              targetLocation: "PATH"
+              requiredMapping: true
+  executionStage:
+    - taskName: delete_order_task
+      taskType: http
+      endpoint:
+        path: "/api/v2/company/{username}/connections/{connectionId}"
+        method: 'DELETE'
+        serverKey: ''
+        mappers:
+          request:
+            - name: mapper.order.eline.delete.buyerId
+              title: "The unique identifier of the organization that is acting as the a Buyer."
+              description: ""
+              source: "@{{buyerId}}"
+              sourceLocation: "QUERY"
+              target: "@{{username}}"
+              targetLocation: "PATH"
+              requiredMapping: false
+            - name: mapper.order.eline.delete.productId
+              title: "The unique identifier of an in-service Product that is the ordering subject"
+              description: ""
+              source: "@{{productOrderItem[*].product.id}}"
+              sourceLocation: "BODY"
+              target: "@{{connectionId}}"
+              targetLocation: "PATH"
+              requiredMapping: true
+      notificationUrl: http://slack.notice/api


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->
Current only api mapper template support merge operation when upgrade template. All other template kinds including workflow use overwrite mode, which means the data configured by customer in running version will be lost after upgrading.

Merge operation on workflow should be supported. Most of the workflow merge operations are same as api mapper, exception for the following aspects:

Cusomer fields:

- HttpTask.endpoint rule: follow 1:1 mapping
- HttpTask.conditionCheck rule: merge user data to new template

System fields:

- HttpTask.taskName
- HttpTask.taskType
- HttpTask.description
- HttpTask.buildInTask
- HttpTask.notificationUrl

rule: use new template

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- Please link to the issue here. -->
https://github.com/mycloudnexus/kraken/issues/593

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)
- [ ] CI/CD or documentation update (changes to CI/CD pipeline or documentation)

## Self Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [x] I ensured that I are not pushing configuration files containing sensitive information such as testing keys.
- [x] I ensured that large PR is avoided,  Consider splitting if there are more than 500 line changes, In addition to line count, also consider the number of files being affected, An ideal amount is less than 10, 25-30 is generally too large with the exception of library upgrades, refactors, etc.
- [x] I ensured that If the PR is inevitably large, a short PR review meeting or discuss with reviewers will be organized.
- [x] I ensured that If the PR is to resolve a blocker, do not make unrelated changes in the same PR e.g. formatting changes, to minimize review time.
- [x] I ensured that PR is focused
- [x] I ensured that context was given in the PR description, Include a clear description of the changes
- [x] I ensured that related github issues are linked, Include screenshots if this will make the context clearer for the reviewer
- [x] I ensured that "work in progress" or "hold" labels are removed
- [x] I ensured that adherence to style guidelines
- [x] I ensured that feature flag is applied if needed
- [x] I ensured that follow secure development practices
- [x] I ensured that no secrets or sensitive data have been committed or logged
- [x] I ensured that no hardcoded values that may change depending on environment (these should be configured dynamically e.g. through environment variables, from the db etc)
