### PR TITLE
feat(sdk): expand the number and boolean type insertion

### DIFF
--- a/kraken-java-sdk/kraken-java-sdk-core/src/test/java/com/consoleconnect/kraken/operator/core/toolkit/JsonPathTests.java
+++ b/kraken-java-sdk/kraken-java-sdk-core/src/test/java/com/consoleconnect/kraken/operator/core/toolkit/JsonPathTests.java
@@ -37,4 +37,15 @@ class JsonPathTests {
     Object jsonObject = mapper.readValue(jsonString, Object.class);
     return mapper.writeValueAsString(jsonObject);
   }
+
+  @SneakyThrows
+  @Test
+  void givenJsonPath_whenGenerateDynamicJson_returnOK() {
+    String s1 = JsonToolkit.generateJsonDynamic("/user/class/0/name", "John", "{}");
+    String s2 = JsonToolkit.generateJsonDynamic("/user/class/0/password", "password", s1);
+    String s3 = JsonToolkit.generateJsonDynamic("/user/class/0/secret/key", "secretKey", s2);
+    String s4 = JsonToolkit.generateJsonDynamic("/user/class/0/deposit/amount", "123456", s3);
+    log.info("final result: {}", s4);
+    assertThat(s4, hasJsonPath("$.user.class[0].deposit.amount", equalTo(123456)));
+  }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->
Refactor JSON value handling to dynamically create the correct JsonNode type (object, array, number, boolean, null, or string) instead of always defaulting to TextNode.

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- Please link to the issue here. -->
https://github.com/mycloudnexus/kraken/issues/811
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)
- [ ] CI/CD or documentation update (changes to CI/CD pipeline or documentation)

## Self Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [x] I ensured that I are not pushing configuration files containing sensitive information such as testing keys.
- [x] I ensured that large PR is avoided,  Consider splitting if there are more than 500 line changes, In addition to line count, also consider the number of files being affected, An ideal amount is less than 10, 25-30 is generally too large with the exception of library upgrades, refactors, etc.
- [x] I ensured that If the PR is inevitably large, a short PR review meeting or discuss with reviewers will be organized.
- [x] I ensured that If the PR is to resolve a blocker, do not make unrelated changes in the same PR e.g. formatting changes, to minimize review time.
- [x] I ensured that PR is focused
- [x] I ensured that context was given in the PR description, Include a clear description of the changes
- [x] I ensured that related github issues are linked, Include screenshots if this will make the context clearer for the reviewer
- [x] I ensured that "work in progress" or "hold" labels are removed
- [x] I ensured that adherence to style guidelines
- [x] I ensured that feature flag is applied if needed
- [x] I ensured that follow secure development practices
- [x] I ensured that no secrets or sensitive data have been committed or logged
- [x] I ensured that no hardcoded values that may change depending on environment (these should be configured dynamically e.g. through environment variables, from the db etc)
